### PR TITLE
Allow specifying SNMP version via parameter

### DIFF
--- a/check_iftraffic.pl
+++ b/check_iftraffic.pl
@@ -93,6 +93,7 @@ my $max_bytes;
 my $status = GetOptions(
 	"h|help"        => \$opt_h,
 	"C|community=s" => \$COMMUNITY,
+	"V|version=s"	=> \$snmp_version,
 	"w|warning=s"   => \$warn_usage,
 	"c|critical=s"  => \$crit_usage,
 	"b|bandwidth=i" => \$iface_speed,

--- a/check_iftraffic.pl
+++ b/check_iftraffic.pl
@@ -349,6 +349,8 @@ sub print_usage {
         Check interface on the indicated host.
     -C --community STRING
         SNMP Community.
+    -V --version STRING
+        SNMP version to use (default: 1)
     -i --interface STRING
         Interface Name
     -b --bandwidth INTEGER


### PR DESCRIPTION
I didn't change the default from SNMPv1 in order to not break existing setups but we are setting up devices now to only support SNMPv2.