### PR TITLE
Added snmp v3 support

### DIFF
--- a/check_iftraffic.pl
+++ b/check_iftraffic.pl
@@ -313,7 +313,7 @@ sub counter_overflow {
     my ($bytes, $last_bytes, $max_bytes) = @_;
 
     $bytes += $max_bytes if ($bytes < $last_bytes);
-    $bytes = 0 if ($bytes < $last_bytes);
+    $bytes = 0 if ($bytes < $last_bytes || $bytes == "");
     return $bytes;
 }
 

--- a/check_iftraffic.pl
+++ b/check_iftraffic.pl
@@ -21,6 +21,8 @@ my $VERSION = "1.0.3";
 
 use strict;
 
+use Crypt::DES;
+
 use Net::SNMP;
 use Getopt::Long;
 &Getopt::Long::config('bundling');
@@ -87,7 +89,7 @@ my $status = GetOptions(
     "J|auth-phrase=s"=> \$authpasswd,
     "k|priv-proto=s" => \$privproto,
     "K|priv-phrase"  => \$privpasswd,
-    "u|user"         => \$username
+    "U|user"         => \$username
 );
 
 if ($status == 0) {

--- a/check_iftraffic.pl
+++ b/check_iftraffic.pl
@@ -88,8 +88,8 @@ my $status = GetOptions(
     "j|auth-proto=s" => \$authproto,
     "J|auth-phrase=s"=> \$authpasswd,
     "k|priv-proto=s" => \$privproto,
-    "K|priv-phrase"  => \$privpasswd,
-    "U|user"         => \$username
+    "K|priv-phrase=s"  => \$privpasswd,
+    "U|user=s"         => \$username
 );
 
 if ($status == 0) {

--- a/check_iftraffic.pl
+++ b/check_iftraffic.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 #
-my $VERSION = "1.0.2";
+my $VERSION = "1.0.3";
 
 # check_iftraffic.pl - Icinga network traffic monitor plugin
 # Copyright (C) 2004 Gerd Mueller / Netways GmbH
@@ -40,11 +40,11 @@ my $error;
 my $port         = 161;
 my $snmp_version = 1;
 
-my $authproto,
-my $authpasswd,
-my $privproto,
-my $privpasswd,
-my $username
+my $authproto;
+my $authpasswd;
+my $privproto;
+my $privpasswd;
+my $username;
 
 my @snmpoids;
 

--- a/check_iftraffic.pl
+++ b/check_iftraffic.pl
@@ -348,13 +348,22 @@ sub print_help {
     -c --critical INTEGER
         % of bandwidth usage necessary to result in critical status (default: 98%)
     -M --max INTEGER
-	Max Counter Value of net devices in kilo/mega/giga/bytes.
-
-    -j 
+	    Max Counter Value of net devices in kilo/mega/giga/bytes.
+    -U --user STRING
+        SNMPv3 User
+    -j --authproto STRING
+        SNMPv3 authentication phrase protocol
+    -J --authphrase STRING
+        SNMPv3 authentication phrase
+    -k --privproto STRING
+        SNMPv3 private phrase protocol
+    -K --privphrase STRING
+        SNMPv3 private phrase
 
      Example:
 
          check_iftraffic.pl -H localhost -C public -i en0 -b 100 -u m
+         check_iftraffic.pl -H localhost -V 3 -i en0 -b 100 -u m -U icinga2 -j SHA -J AUTHPHRASEHERE -k AES -K PRIVATEPHRASEHERE
 EOT
 
     exit($ERRORS{"UNKNOWN"});

--- a/check_iftraffic.pl
+++ b/check_iftraffic.pl
@@ -40,6 +40,12 @@ my $error;
 my $port         = 161;
 my $snmp_version = 1;
 
+my $authproto,
+my $authpasswd,
+my $privproto,
+my $privpasswd,
+my $username
+
 my @snmpoids;
 
 # SNMP OIDs for Traffic

--- a/check_iftraffic.pl
+++ b/check_iftraffic.pl
@@ -65,18 +65,23 @@ my $max_value;
 my $max_bytes;
 
 my $status = GetOptions(
-    "h|help"        => \$opt_h,
-    "v"             => \$opt_version,
-    "C|community=s" => \$COMMUNITY,
-    "V|version=s"   => \$snmp_version,
-    "w|warning=s"   => \$warn_usage,
-    "c|critical=s"  => \$crit_usage,
-    "b|bandwidth=i" => \$iface_speed,
-    "p|port=i"      => \$port,
-    "u|units=s"     => \$units,
-    "i|interface=s" => \$iface_descr,
-    "H|hostname=s"  => \$host_address,
-    "M|max=i"       => \$max_value
+    "h|help"         => \$opt_h,
+    "v"              => \$opt_version,
+    "C|community=s"  => \$COMMUNITY,
+    "V|version=s"    => \$snmp_version,
+    "w|warning=s"    => \$warn_usage,
+    "c|critical=s"   => \$crit_usage,
+    "b|bandwidth=i"  => \$iface_speed,
+    "p|port=i"       => \$port,
+    "u|units=s"      => \$units,
+    "i|interface=s"  => \$iface_descr,
+    "H|hostname=s"   => \$host_address,
+    "M|max=i"        => \$max_value,
+    "j|auth-proto=s" => \$authproto,
+    "J|auth-phrase=s"=> \$authpasswd,
+    "k|priv-proto=s" => \$privproto,
+    "K|priv-phrase"  => \$privpasswd,
+    "u|user"         => \$username
 );
 
 if ($status == 0) {
@@ -113,9 +118,23 @@ if ($snmp_version =~ /[12]/) {
         exit $ERRORS{'UNKNOWN'};
     }
 } elsif ($snmp_version =~ /3/) {
-    my $state = 'UNKNOWN';
-    print("$state: No support for SNMP v3 yet\n");
-    exit $ERRORS{$state};
+    ($session, $error) = Net::SNMP->session(
+        -hostname       => $host_address,
+        -port           => $port,
+        -version        => $snmp_version,
+        -username       => $username, # v3
+        #-authkey        => $authkey, # v3
+        -authpassword   => $authpasswd, # v3
+        -authprotocol   => $authproto, # v3
+        #-privkey        => $privkey, # v3
+        -privpassword   => $privpasswd, # v3
+        -privprotocol   => $privproto # v3
+    );
+
+    if (!defined($session)) {
+        print("UNKNOWN: $error");
+        exit $ERRORS{'UNKNOWN'};
+    }
 } else {
     my $state = 'UNKNOWN';
     print("$state: No support for SNMP v$snmp_version yet\n");

--- a/check_iftraffic.pl
+++ b/check_iftraffic.pl
@@ -348,7 +348,7 @@ sub print_help {
     -c --critical INTEGER
         % of bandwidth usage necessary to result in critical status (default: 98%)
     -M --max INTEGER
-	    Max Counter Value of net devices in kilo/mega/giga/bytes.
+	Max Counter Value of net devices in kilo/mega/giga/bytes.
     -U --user STRING
         SNMPv3 User
     -j --authproto STRING

--- a/check_iftraffic.pl
+++ b/check_iftraffic.pl
@@ -85,11 +85,11 @@ my $status = GetOptions(
     "i|interface=s"  => \$iface_descr,
     "H|hostname=s"   => \$host_address,
     "M|max=i"        => \$max_value,
-    "j|auth-proto=s" => \$authproto,
-    "J|auth-phrase=s"=> \$authpasswd,
-    "k|priv-proto=s" => \$privproto,
-    "K|priv-phrase=s"  => \$privpasswd,
-    "U|user=s"         => \$username
+    "j|authproto=s"  => \$authproto,
+    "J|authphrase=s" => \$authpasswd,
+    "k|privproto=s"  => \$privproto,
+    "K|privphrase=s" => \$privpasswd,
+    "U|user=s"       => \$username
 );
 
 if ($status == 0) {
@@ -349,6 +349,8 @@ sub print_help {
         % of bandwidth usage necessary to result in critical status (default: 98%)
     -M --max INTEGER
 	Max Counter Value of net devices in kilo/mega/giga/bytes.
+
+    -j 
 
      Example:
 

--- a/check_iftraffic.pl
+++ b/check_iftraffic.pl
@@ -313,7 +313,7 @@ sub counter_overflow {
     my ($bytes, $last_bytes, $max_bytes) = @_;
 
     $bytes += $max_bytes if ($bytes < $last_bytes);
-    $bytes = 0 if ($bytes < $last_bytes || $bytes == "");
+    $bytes = 0 if ($bytes < $last_bytes);
     return $bytes;
 }
 


### PR DESCRIPTION
Hello all,

I have upgraded the check to snmp v3.

OS: Debian GNU/Linux 11 (bullseye) x86_64
Host: KVM Server
Kernel: 5.10.0-12-amd64

This is perl 5, version 32, subversion 1 (v5.32.1) built for x86_64-linux-gnu-thread-multi


./check_iftraffic.pl -H localhost -V 3 -i 'Red Hat, Inc. Device 0001' -b 1000 -u m -j SHA -J AUTHPHRASE-k AES -K PRIVATEPHRASE -U icinga2

Total RX Bytes: 310.28 MB, Total TX Bytes: 89.63 MB<br>Average Traffic: 3.36 kB/s (0.0%) in, 0.64 kB/s (0.0%) out|inUsage=0.0%;85;98 outUsage=0.0%;85;98 inAbsolut=317445c outAbsolut=91725c

Please check the changes and see if everything is ok. 

Many thanks and best regards,
Mücke